### PR TITLE
[FIX] Window resize

### DIFF
--- a/Scenes/main.tscn
+++ b/Scenes/main.tscn
@@ -57,14 +57,13 @@ autostart = true
 [node name="HUD" type="CanvasLayer" parent="."]
 
 [node name="MessageLabel" type="Label" parent="HUD"]
-visible = false
-offset_left = 298.0
-offset_top = 234.0
-offset_right = 860.0
-offset_bottom = 420.0
+offset_left = 173.0
+offset_top = 228.0
+offset_right = 997.0
+offset_bottom = 417.0
 text = "GAME OVER 
 
-I DID KNOW U SUCK ):"
+All his friends miss him now"
 label_settings = SubResource("LabelSettings_fv8ou")
 horizontal_alignment = 1
 
@@ -78,7 +77,6 @@ label_settings = SubResource("LabelSettings_ju8g3")
 horizontal_alignment = 2
 
 [node name="StartButton" type="Button" parent="HUD"]
-visible = false
 offset_left = 451.0
 offset_top = 452.0
 offset_right = 707.0

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://Scenes/main.tscn"
 config/features=PackedStringArray("4.1", "Mobile")
 config/icon="res://icon.svg"
 
+[display]
+
+window/stretch/mode="viewport"
+
 [input]
 
 Flap={


### PR DESCRIPTION
This PR addresses #1

Previously, the screen would break when the user resized the window.

Before

https://github.com/user-attachments/assets/b398866e-f8c3-498a-9003-702900aaafc0





Now

https://github.com/user-attachments/assets/952b940d-55e2-4ab9-a7bc-c5ace52e204d


